### PR TITLE
Allow the backup auditor role to browse in AWS S3 console

### DIFF
--- a/src/s3_sysbackup/cf_templates/resources.yml
+++ b/src/s3_sysbackup/cf_templates/resources.yml
@@ -252,12 +252,28 @@ Resources:
                 's3:prefix':
                   - 'manifests/*'
                   - 'content/*'
+                  - 'snapshots/*'
+          - Effect: Allow
+            Action:
+              - 's3:ListBucket'
+            Resource:
+              - {'Fn::Sub': "${Bucket.Arn}"}
+            Condition:
+              StringEquals:
+                's3:delimiter': '/'
+              StringNotLike:
+                's3:prefix': '?*'
           - Effect: Allow
             Action:
               - 's3:GetObject'
               - 's3:GetObjectVersion'
             Resource:
               - {'Fn::Sub': "${Bucket.Arn}/manifests/*"}
+          - Effect: Allow
+            Action:
+              - 's3:GetObjectRetention'
+            Resource:
+              - {'Fn::Sub': "${Bucket.Arn}/*"}
   
   AuditRole:
     # REQUIRES (on stack creation/update): CAPABILITY_NAMED_IAM


### PR DESCRIPTION
To view the bucket in the AWS console, the auditor needs to be able to
list the bucket with an empty string `prefix` and the slash delimiter.

The auditor also needs to be able to verify the existence of the correct
snapshots and to verify retention settings of any object in the bucket.

Closes #5